### PR TITLE
很小很小的 bug (挑刺儿)

### DIFF
--- a/app/src/main/java/com/qwe7002/telegram_rc/chat_command_service.java
+++ b/app/src/main/java/com/qwe7002/telegram_rc/chat_command_service.java
@@ -446,11 +446,13 @@ public class chat_command_service extends Service {
                 int command_end_offset = command_offset + entities_obj_command.get("length").getAsInt();
                 temp_command = request_msg.substring(command_offset, command_end_offset).trim();
                 temp_command_lowercase = temp_command.toLowerCase().replace("_", "");
-                command = temp_command_lowercase;
-                if (temp_command_lowercase.contains("@")) {
-                    int command_at_location = temp_command_lowercase.indexOf("@");
+                int command_at_location = temp_command_lowercase.lastIndexOf("@");
+                
+                if (command_at_location != -1) {
                     command = temp_command_lowercase.substring(0, command_at_location);
                     command_bot_username = temp_command.substring(command_at_location + 1);
+                }else{
+                    command = temp_command_lowercase;
                 }
             }
         }


### PR DESCRIPTION
bug: 如果消息文字是 "aaa@bbb@ccc" 的话, 变量 command_bot_username 会错误的变为 "bbb@ccc". 应使用 lastIndexOf() 而非 indexOf() (也就是寻找方向反了, 从后向前找)

性能提升: 在有 @ 时, 节约一次无意义的 String 复制时间(实际上这个过程可能被java优化掉了); 不再扫描两次 "@" 而是一次.(contain 要扫一次, indexof 要扫一次)(尽管没啥实际影响)

另外要是还要提升性能的话可以先摸到 username ,然后存下 "@username", 最后在有username时(网没卡时)用 endsWith()来替代

当然再缺德就是利用"tg不会把别的机器人的消息发给你除非你有特权"的规则并检查自己有没有群管权限了...(脑袋进水才会这么干吧)